### PR TITLE
Multiple selector will throw error while name has space at beginning

### DIFF
--- a/projects/mat-reduce-core/src/lib/utils/tag-helper.ts
+++ b/projects/mat-reduce-core/src/lib/utils/tag-helper.ts
@@ -4,7 +4,7 @@ export function doesTextMatch(text1: string, text2: string): boolean {
   }
   const text1Safe = text1 + '';
   const text2Safe = text2 + '';
-  const matches = text1Safe.toLowerCase() === text2Safe.toLowerCase();
+  const matches = text1Safe.toLowerCase().trim() === text2Safe.toLowerCase().trim();
   return matches;
 }
 

--- a/projects/mat-reduce-demo/src/app/test-material/test-formgroup.component.ts
+++ b/projects/mat-reduce-demo/src/app/test-material/test-formgroup.component.ts
@@ -7,7 +7,7 @@ import { Tag } from '../from-mat-reduce-core';
 
 function makeTag(name): Tag {
   return {
-    name,
+    name: name.trim(),
     id: uuidv1()
   };
 }

--- a/projects/mat-reduce-demo/src/app/test-material/test-tag-strings.component.ts
+++ b/projects/mat-reduce-demo/src/app/test-material/test-tag-strings.component.ts
@@ -7,7 +7,7 @@ import { Tag } from '../from-mat-reduce-core';
 
 function makeTag(name): Tag {
   return {
-    name,
+    name: name.trim(),
     id: uuidv1(),
   };
 }

--- a/projects/mat-reduce-demo/src/app/test-material/test-tags.component.ts
+++ b/projects/mat-reduce-demo/src/app/test-material/test-tags.component.ts
@@ -7,13 +7,13 @@ import { Tag } from '../from-mat-reduce-core';
 
 function makeTag(name): Tag {
   return {
-    name,
+    name: name.trim(),
     id: uuidv1(),
   };
 }
 
 const friendArray = [
-  makeTag('Albert'),
+  makeTag(' Albert'),
   makeTag('Alison'),
   makeTag('Cindy'),
   makeTag('Daniel'),


### PR DESCRIPTION
Hi Ben,

We came an issue with tag. If tag is like 
`{name: ' test', id: 'x123'}` which has space at beginning, it will push null into selected array and it will throws error and keep complaint in the console. So I added trim() in compare function and also updated test function. 
![Screen Shot 2021-11-03 at 1 59 15 pm](https://user-images.githubusercontent.com/53634020/140007832-9ff3635f-d3e8-4ea0-a7a0-55948b920849.png)


I hope this could fix issue. Thanks and have a great day!
Wyatt

